### PR TITLE
ci: add permissions to workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,9 @@ on:
       - "docs/**"
       - ".github/workflows/publish.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     uses: tailstory-wiki/builder/.github/workflows/build.yaml@main


### PR DESCRIPTION
Potential fix for [https://github.com/tailstory-wiki/fedex-shipmanager/security/code-scanning/2](https://github.com/tailstory-wiki/fedex-shipmanager/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/publish.yaml` so all jobs (including the reusable `build-and-publish` job) inherit least-privilege defaults.

Best single fix without changing intended functionality:
- Insert at top-level (after `on:` block and before `jobs:`):
  - `permissions:`
  - `contents: read`

This documents and enforces restricted token scope. `contents: read` is the minimal common permission for most checkout/read operations. If the reusable workflow later needs additional scopes, those can be added explicitly (for example `packages: read`), but the current finding is resolved by defining explicit permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
