### PR TITLE
Adopt curated tabs, tsy.topic frontmatter, and a documentation cap entry

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: landing.njk
+ms.topic: hub-page
 title: FedEx Ship Manager
 description: FedEx shipping software for printing labels and uploading manifests.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: landing.njk
-ms.topic: hub-page
+tsy.topic: hub-page
 title: FedEx Ship Manager
 description: FedEx shipping software for printing labels and uploading manifests.
 ---

--- a/docs/toc.yaml
+++ b/docs/toc.yaml
@@ -1,5 +1,8 @@
+tabs:
+  - title: Troubleshooting
+    page: troubleshooting
 entries:
-  - title: Overview
+  - title: FedEx Ship Manager documentation
     page: index
   - title: Troubleshooting
     page: troubleshooting


### PR DESCRIPTION
Content half of the bespoke-navigation follow-up for FedEx Ship Manager.

## Changes

- **`docs/toc.yaml`** — declares the curated subnav `tabs` (just Troubleshooting — the self-referential Overview tab is gone) and renames the "Overview" entry to "FedEx Ship Manager documentation", the cap shown atop the TOC rail on regular pages.
- **`docs/index.md`** — `tsy.topic: hub-page`: the product home renders without a TOC rail.

## Merge order — merge last, after builder and worker

- builder: tailstory-wiki/builder#14 (schema must accept `tabs:`, layouts must stamp `tsy.topic` — merging this PR first fails publish CI on schema validation)
- worker: tailstory-wiki/worker#28 (renders the new data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ChgTfW9YbmzB2GMkvm1Se